### PR TITLE
Setup `npm test` script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ If you have a client build process and need to compile handlebars templates for 
 
 To run the tests
 
-    cd tests
-    ./runner.sh
+    npm tests
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/toranb/ember-template-compiler"
   },
+  "scripts": {
+    "test": "./node_modules/jasmine-node/bin/jasmine-node tests/"
+  },
   "keywords": [
     "Ember.js",
     "Handlebars.js"
@@ -25,6 +28,8 @@
     "MIT"
   ],
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "jasmine-node": "~1.11"
+  },
   "optionalDependencies": {}
 }

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -5,7 +5,7 @@ var path = require('path');
 describe("ember-template-compiler tests", function() {
 
   it("compiles down a handlebars template", function() {
-    var template = fs.readFileSync(path.join('file-system', 'app', 'templates', 'foo.handlebars')).toString();
+    var template = fs.readFileSync(path.join(path.dirname(fs.realpathSync(__filename)),'file-system', 'app', 'templates', 'foo.handlebars')).toString();
     var result = sut.precompile(template).toString();
     expect(result).toContain("outlet");
   });

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-npm install jasmine-node
-
-for file in *; do
-  if [ ${file: -8} == ".spec.js" ]; then
-    ../node_modules/jasmine-node/bin/jasmine-node "$file"
-  fi
-done


### PR DESCRIPTION
This commit adds `jasmine-node` as to `devDependencies` and removes the `tests/runner.sh` script. Now tests can be run from the projects root directory with `npm test`.

`npm test` is the default test script used by Travis for Node projects.
