### PR TITLE
Latest handlebars 1.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "dependencies": {},
   "devDependencies": {
     "jasmine-node": "~1.11",
-    "handlebars": "~1.1"
+    "handlebars": "~1"
   },
   "peerDependencies": {
-    "handlebars": "~1.1"
+    "handlebars": "~1"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
This allows handlebars 1.2 and fixes the following error:

```
Failed to update/save devDependencies { [Error: The package handlebars does not satisfy its siblings' peerDependencies requirements!]
  code: 'EPEERINVALID',
  packageName: 'handlebars',
  peersDepending: { 'ember-template-compiler@1.2.0': '~1.1' } }
```

NPM is using a different 1.x syntax then bundler: https://github.com/components/ember-data/issues/18#issuecomment-30973378
