### PR TITLE
Expose asObject parameter to precompile function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ If you have a client build process and need to compile handlebars templates for 
     var input = compiler.precompile(template).toString();
     var output = "Ember.TEMPLATES['foo'] = Ember.Handlebars.template(" + input + ");";
 
+Additionally you can pass a second argument into `precompile` which will build the precompiled template as an object (`true` or `undefined`) or as a string (`false`).  Building as a string is more efficient than building as an object then converting it to a string. 
+
+    var input = compiler.precompile(template, false);
+    var output = "Ember.TEMPLATES['foo'] = Ember.Handlebars.template(" + input + ");";
+
 ##Handlebars Version
 
 This package will utilize any recent Handlebars version. To require a specific version
@@ -19,7 +24,7 @@ simply specify it in your `package.json`. By default the latest 1.x version will
 
 ##Development
 
-To run the tests
+To run the tests you must have the following node packages installed: `jasmine-node`, and `handlebars`.  Then run
 
     npm test
 

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -3,11 +3,27 @@ var fs = require('fs');
 var path = require('path');
 
 describe("ember-template-compiler tests", function() {
+  var result,
+      template = fs.readFileSync(path.join(path.dirname(fs.realpathSync(__filename)),'file-system', 'app', 'templates', 'foo.handlebars')).toString();
 
   it("compiles down a handlebars template", function() {
-    var template = fs.readFileSync(path.join(path.dirname(fs.realpathSync(__filename)),'file-system', 'app', 'templates', 'foo.handlebars')).toString();
-    var result = sut.precompile(template).toString();
+    result = sut.precompile(template).toString();
     expect(result).toContain("outlet");
+  });
+
+  it("compiles down a handlebars template to a function when asObject isn't defined", function() {
+    result = sut.precompile(template);
+    expect(typeof(result)).toBe("function");
+  });
+
+  it("compiles down a handlebars template to a function when passed asObject=true", function() {
+    result = sut.precompile(template, true);
+    expect(typeof(result)).toBe("function");
+  });
+
+  it("compiles down a handlebars template to a string when asObject=false", function() {
+    result = sut.precompile(template, false);
+    expect(typeof(result)).toBe("string");
   });
 
 });

--- a/vendor/ember-template-compiler.js
+++ b/vendor/ember-template-compiler.js
@@ -268,8 +268,10 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
   @for Ember.Handlebars
   @static
   @param {String} string The template to precompile
+  @param {Boolean} asObject optional parameter, defaulting to true, of whether or not the 
+                            compiled template should be returned as an Object or a String
 */
-Ember.Handlebars.precompile = function(string) {
+Ember.Handlebars.precompile = function(string, asObject) {
   var ast = Handlebars.parse(string);
 
   var options = {
@@ -285,8 +287,10 @@ Ember.Handlebars.precompile = function(string) {
     stringParams: true
   };
 
+  asObject = asObject === undefined ? true : asObject;
+
   var environment = new Ember.Handlebars.Compiler().compile(ast, options);
-  return new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
+  return new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, asObject);
 };
 
 // We don't support this for Handlebars runtime-only


### PR DESCRIPTION
Allow precompilation to return a string instead of an object
