### PR TITLE
Require node >= 0.8.19.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ember-template-compiler": "./bin/compiler"
   },
   "engines": {
-    "node": ">=v0.8.1"
+    "node": ">=v0.8.19"
   },
   "licenses": [
     "MIT"


### PR DESCRIPTION
This project is using peerDependencies to ensure that the Handlebars dependency is setup properly (and can be overridden by our consumers). In practice this works wonderfully, but a few users with older Node.js and/or NPM versions simple get a broken build. This is because Node.js < 0.8.19 did not have the ability to handle peerDependencies specified in the `package.json`.

This changes to ensure that at least 0.8.19 (well over a year old) is used, and provides the user with a reasonable error message (indicating that their Node.js version is too old).

If this is unacceptable, we could attempt to detect this upon first use, and fail loudly if Handlebars is not found.

@toranb - I opened this up as a PR to make sure we are on the same page on this. Are you OK with requiring 0.8.19+?
